### PR TITLE
Backporting changes to make repo names/URLs in episode 07 dyanmic

### DIFF
--- a/_episodes/07-containers-in-practice.md
+++ b/_episodes/07-containers-in-practice.md
@@ -15,18 +15,18 @@ The website for this lesson is generated mechanically, based on a set of files t
 However, these advantages come with a major disadvantage: we need to install the Jekyll framework to build the website and preview what effect our changes have. Jekyll is written in Ruby, has a large list of dependencies and can be complex to install and maintain. Containers to the rescue!
 
 Now open a web browser window and:
-1. Navigate to the GitHub repository that contains the files for this session, at <https://github.com/ARCHER-CSE/2020-02-03-durham-docker>;
-2. Click the green "Clone or download" button on the right-hand side of the page;
+1. Navigate to the GitHub repository that contains the files for this session, at <{{ site.github.repository_url }}>;
+2. Click the green "Code" button on the right-hand side of the page;
 3. Click "Download ZIP".
-4. Expand the downloaded ZIP file. It should contain one directory named `2020-02-03-durham-docker-gh-pages`.
+4. Expand the downloaded ZIP file. It should contain one directory named `{{ site.github.repository_name }}-{{ site.github.source.branch }}`.
 
 > ## There are many ways to work with ZIP files
-> Note that the last two steps can be achieved using a Mac or Windows graphical user interface. There are also ways to effect expanding the ZIP archive on the command line, for example, on my Mac I can achieve the effect of those last two steps through running the command `unzip 2020-02-03-durham-docker-gh-pages.zip`.
+> Note that the last two steps can be achieved using a Mac or Windows graphical user interface. There are also ways to effect expanding the ZIP archive on the command line, for example, on my Mac I can achieve the effect of those last two steps through running the command `unzip {{ site.github.repository_name }}-{{ site.github.source.branch }}.zip`.
 {: .callout}
 
-In your shell window, if you `cd` into the `2020-02-03-durham-docker-gh-pages` folder and list the files, you should see something similar to what I see:
+In your shell window, if you `cd` into the `{{ site.github.repository_name }}-{{ site.github.source.branch }}` folder and list the files, you should see something similar to what I see:
 ~~~
-$ cd 2020-02-03-durham-docker-gh-pages
+$ cd {{ site.github.repository_name }}-{{ site.github.source.branch }}
 $ ls
 ~~~
 {: .language-bash}
@@ -92,9 +92,9 @@ Configuration file: /srv/jekyll/_config.yml
 
 In the preceding output, you see Docker downloading the image for Jekyll, which is a tool for building websites from specification files such as those used for this lesson. The line `jekyll serve` indicates a command that runs within the Docker container instance. The output below that is from the Jekyll tool itself, highlighting that the website has been built, and indicating that there is a server running.
 
-Open a web browser window and visit the address <http://localhost:4000/>. You should see a site that looks very similar to that at <https://archer-cse.github.io/2020-02-03-durham-docker/>.
+Open a web browser window and visit the address <http://localhost:4000/>. You should see a site that looks very similar to that at <{{ site.github.url }}>.
 
-Using a new shell window, or using your laptop's GUI, locate the file `index.md` within the `2020-02-03-durham-docker-gh-pages` directory, and open it in your preferred editor program.
+Using a new shell window, or using your laptop's GUI, locate the file `index.md` within the `{{ site.github.repository_name }}-{{ site.github.source.branch }}` directory, and open it in your preferred editor program.
 
 Near the top of this file you should see the description starting "This session aims to introduce the use of Docker containers with the goal of using them to effect reproducible computational environments." Make a change to this message, and save the file.
 


### PR DESCRIPTION
Removes hard-coding of repository name and URLs in episode 7. Also fixes "Clone" button naming since this has changed in the new GitHub UI.